### PR TITLE
Update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ regex = "1.5.4"
 rust-htslib = "0.43.1"
 serde = {version = "1.0.104", features = ["derive"]}
 serde_json = "1.0.48"
-spin = "0.9.4"
+spin = "0.9.8"
 #syn = "0.15.20"
 bamlift = {version = "0.1.0", path = "bamlift"}
 tch = {version = "0.13.0", optional = true}


### PR DESCRIPTION
Updates dependency to the patch version of 0.9.8

[Advisory](https://rustsec.org/advisories/RUSTSEC-2023-0031.html)