### PR TITLE
Add a QC command that calculates basic statistics on a ft bam

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -117,6 +117,8 @@ pub enum Commands {
     Center(CenterOptions),
     /// Infer footprints from fiberseq data
     Footprint(FootprintOptions),
+    /// Collect QC metrics from a fiberseq bam file
+    Qc(QcOpts),
     /// Make decorated bed files for fiberseq data
     TrackDecorators(DecoratorOptions),
     /// Make a pileup track of Fiber-seq features from a FIRE bam

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -107,12 +107,12 @@ pub enum Commands {
     Fire(FireOptions),
     /// Extract fiberseq data into plain text files.
     ///
-    /// See https://fiberseq.github.io/fibertools-rs/docs/extract.html for a description of the outputs.
+    /// See https://fiberseq.github.io/fibertools/extracting/extract.html for a description of the outputs.
     #[clap(visible_aliases = &["ex", "e"])]
     Extract(ExtractOptions),
     /// This command centers fiberseq data around given reference positions. This is useful for making aggregate m6A and CpG observations, as well as visualization of SVs.
     ///
-    ///  See https://fiberseq.github.io/fibertools-rs/docs/center.html for a description of the output.
+    ///  See https://fiberseq.github.io/fibertools/extracting/center.html for a description of the output.
     #[clap(visible_aliases = &["c", "ct"])]
     Center(CenterOptions),
     /// Infer footprints from fiberseq data

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -14,6 +14,7 @@ mod footprint_opts;
 mod nucleosome_opts;
 mod pileup_opts;
 mod predict_opts;
+mod qc_opts;
 mod strip_basemods_opts;
 
 // include the subcommand modules as top level functions and structs in the cli module
@@ -27,6 +28,7 @@ pub use footprint_opts::*;
 pub use nucleosome_opts::*;
 pub use pileup_opts::*;
 pub use predict_opts::*;
+pub use qc_opts::*;
 pub use strip_basemods_opts::*;
 
 //

--- a/src/cli/predict_opts.rs
+++ b/src/cli/predict_opts.rs
@@ -26,6 +26,9 @@ pub struct PredictM6AOptions {
     /// Increasing improves GPU performance at the cost of memory.
     #[clap(short, long, default_value = "1", help_heading = "Developer-Options")]
     pub batch_size: usize,
+    /// Skip the actual prediction step to allow for testing the speed of other parts of the code
+    #[clap(long, help_heading = "Developer-Options", hide = true)]
+    pub fake: bool,
 }
 
 impl std::default::Default for PredictM6AOptions {
@@ -38,6 +41,7 @@ impl std::default::Default for PredictM6AOptions {
             force_min_ml_score: None,
             all_calls: false,
             batch_size: 1,
+            fake: false,
         }
     }
 }

--- a/src/cli/qc_opts.rs
+++ b/src/cli/qc_opts.rs
@@ -1,0 +1,9 @@
+use crate::utils::input_bam::InputBam;
+use clap::Args;
+use std::fmt::Debug;
+
+#[derive(Args, Debug)]
+pub struct QcOpts {
+    #[clap(flatten)]
+    pub input: InputBam,
+}

--- a/src/cli/qc_opts.rs
+++ b/src/cli/qc_opts.rs
@@ -6,8 +6,12 @@ use std::fmt::Debug;
 pub struct QcOpts {
     #[clap(flatten)]
     pub input: InputBam,
+    /// Output text file with QC metrics. The format is a tab-separated file with the following columns: "statistic\tvalue\tcount" where "statistic" is the name of the metric, "value" is the value of the metric, and "count" is the number of times the metric was observed.
     #[clap(default_value = "-")]
     pub out: String,
+    /// In the output include a measure of the number of m6A events per MSPs of a given size.
+    /// The output format is: "m6a_per_msp_size\t{m6A count},{MSP size},{is a FIRE}\t{count}"
+    /// e.g. "m6a_per_msp_size\t35,100,false\t100"
     #[clap(short, long)]
     pub m6a_per_msp: bool,
 }

--- a/src/cli/qc_opts.rs
+++ b/src/cli/qc_opts.rs
@@ -6,6 +6,6 @@ use std::fmt::Debug;
 pub struct QcOpts {
     #[clap(flatten)]
     pub input: InputBam,
-    #[clap(short, long, default_value = "-")]
+    #[clap(default_value = "-")]
     pub out: String,
 }

--- a/src/cli/qc_opts.rs
+++ b/src/cli/qc_opts.rs
@@ -8,4 +8,6 @@ pub struct QcOpts {
     pub input: InputBam,
     #[clap(default_value = "-")]
     pub out: String,
+    #[clap(short, long)]
+    pub m6a_per_msp: bool,
 }

--- a/src/cli/qc_opts.rs
+++ b/src/cli/qc_opts.rs
@@ -6,4 +6,6 @@ use std::fmt::Debug;
 pub struct QcOpts {
     #[clap(flatten)]
     pub input: InputBam,
+    #[clap(short, long, default_value = "-")]
+    pub out: String,
 }

--- a/src/m6a_burn/mod.rs
+++ b/src/m6a_burn/mod.rs
@@ -82,10 +82,6 @@ where
         if count == 0 {
             return vec![];
         }
-        // allow fake predictions for testing speed of other parts of the code
-        if opts.fake {
-            return vec![0.0; count];
-        }
 
         let shape = Shape::new([count, LAYERS, WINDOW]);
         let input =
@@ -97,7 +93,10 @@ where
             PbChem::ThreePointTwo => self.three_two.forward(input),
             PbChem::Revio => self.revio.forward(input),
         };
-
+        // allow fake predictions for testing speed of other parts of the code
+        if opts.fake {
+            return vec![0.0; count];
+        }
         forward
             .into_data()
             .convert()

--- a/src/m6a_burn/mod.rs
+++ b/src/m6a_burn/mod.rs
@@ -23,18 +23,6 @@ pub type BurnDevice = burn::backend::libtorch::LibTorchDevice;
 #[cfg(not(feature = "tch"))]
 pub type BurnDevice = burn::backend::candle::CandleDevice;
 
-/// enum that can hold the different models for the different polymerases
-#[derive(Debug)]
-pub enum BurnModel<B>
-where
-    B: Backend<Device = BurnDevice>,
-{
-    TwoZero(two_zero::Model<B>),
-    TwoTwo(two_two::Model<B>),
-    ThreeTwo(three_two::Model<B>),
-    Revio(revio::Model<B>),
-}
-
 /// B is for the burn backend and D is for the device
 #[derive(Debug)]
 pub struct BurnModels<B>

--- a/src/m6a_burn/mod.rs
+++ b/src/m6a_burn/mod.rs
@@ -82,6 +82,10 @@ where
         if count == 0 {
             return vec![];
         }
+        // allow fake predictions for testing speed of other parts of the code
+        if opts.fake {
+            return vec![0.0; count];
+        }
 
         let shape = Shape::new([count, LAYERS, WINDOW]);
         let input =

--- a/src/m6a_burn/mod.rs
+++ b/src/m6a_burn/mod.rs
@@ -23,16 +23,28 @@ pub type BurnDevice = burn::backend::libtorch::LibTorchDevice;
 #[cfg(not(feature = "tch"))]
 pub type BurnDevice = burn::backend::candle::CandleDevice;
 
+/// enum that can hold the different models for the different polymerases
+#[derive(Debug)]
+pub enum BurnModel<B>
+where
+    B: Backend<Device = BurnDevice>,
+{
+    TwoZero(two_zero::Model<B>),
+    TwoTwo(two_two::Model<B>),
+    ThreeTwo(three_two::Model<B>),
+    Revio(revio::Model<B>),
+}
+
 /// B is for the burn backend and D is for the device
 #[derive(Debug)]
 pub struct BurnModels<B>
 where
     B: Backend<Device = BurnDevice>,
 {
-    pub two_zero: two_zero::Model<B>,
-    pub two_two: two_two::Model<B>,
-    pub three_two: three_two::Model<B>,
-    pub revio: revio::Model<B>,
+    pub two_zero: Option<two_zero::Model<B>>,
+    pub two_two: Option<two_two::Model<B>>,
+    pub three_two: Option<three_two::Model<B>>,
+    pub revio: Option<revio::Model<B>>,
     pub device: BurnDevice,
 }
 
@@ -40,26 +52,56 @@ impl<B> BurnModels<B>
 where
     B: Backend<Device = BurnDevice>,
 {
-    pub fn new() -> Self {
+    pub fn new(polymerase: &PbChem) -> Self {
         #[cfg(not(feature = "tch"))]
         let device = B::Device::default();
         #[cfg(feature = "tch")]
         let device = Self::get_libtorch_device();
 
-        let two_zero = two_zero::Model::default().to_device(&device);
-        let two_two = two_two::Model::default().to_device(&device);
-        let three_two = three_two::Model::default().to_device(&device);
-        let revio = revio::Model::default().to_device(&device);
-
         // log info about the device used
         log::info!("Using {:?} for Burn device.", device);
 
-        Self {
-            two_zero,
-            two_two,
-            three_two,
-            revio,
-            device,
+        match polymerase {
+            PbChem::Two => {
+                let two_zero = two_zero::Model::default().to_device(&device);
+                Self {
+                    two_zero: Some(two_zero),
+                    two_two: None,
+                    three_two: None,
+                    revio: None,
+                    device,
+                }
+            }
+            PbChem::TwoPointTwo => {
+                let two_two = two_two::Model::default().to_device(&device);
+                Self {
+                    two_zero: None,
+                    two_two: Some(two_two),
+                    three_two: None,
+                    revio: None,
+                    device,
+                }
+            }
+            PbChem::ThreePointTwo => {
+                let three_two = three_two::Model::default().to_device(&device);
+                Self {
+                    two_zero: None,
+                    two_two: None,
+                    three_two: Some(three_two),
+                    revio: None,
+                    device,
+                }
+            }
+            PbChem::Revio => {
+                let revio = revio::Model::default().to_device(&device);
+                Self {
+                    two_zero: None,
+                    two_two: None,
+                    three_two: None,
+                    revio: Some(revio),
+                    device,
+                }
+            }
         }
     }
 
@@ -88,15 +130,16 @@ where
             Tensor::<B, 1, burn::tensor::Float>::from_floats(windows, &self.device).reshape(shape);
 
         // allow fake predictions for testing speed of other parts of the code
+        // I have moved this chunk around and it is indeed just the model.forward
+        // step that is slow
         if opts.fake {
             return vec![0.0; count];
         }
-
         let forward: Tensor<B, 2, burn::tensor::Float> = match opts.polymerase {
-            PbChem::Two => self.two_zero.forward(input),
-            PbChem::TwoPointTwo => self.two_two.forward(input),
-            PbChem::ThreePointTwo => self.three_two.forward(input),
-            PbChem::Revio => self.revio.forward(input),
+            PbChem::Two => self.two_zero.as_ref().unwrap().forward(input),
+            PbChem::TwoPointTwo => self.two_two.as_ref().unwrap().forward(input),
+            PbChem::ThreePointTwo => self.three_two.as_ref().unwrap().forward(input),
+            PbChem::Revio => self.revio.as_ref().unwrap().forward(input),
         };
         forward
             .into_data()
@@ -105,15 +148,6 @@ where
             .chunks(2)
             .map(|c| c[0])
             .collect()
-    }
-}
-
-impl<B> Default for BurnModels<B>
-where
-    B: Backend<Device = BurnDevice>,
-{
-    fn default() -> Self {
-        Self::new()
     }
 }
 

--- a/src/m6a_burn/mod.rs
+++ b/src/m6a_burn/mod.rs
@@ -87,16 +87,17 @@ where
         let input =
             Tensor::<B, 1, burn::tensor::Float>::from_floats(windows, &self.device).reshape(shape);
 
+        // allow fake predictions for testing speed of other parts of the code
+        if opts.fake {
+            return vec![0.0; count];
+        }
+
         let forward: Tensor<B, 2, burn::tensor::Float> = match opts.polymerase {
             PbChem::Two => self.two_zero.forward(input),
             PbChem::TwoPointTwo => self.two_two.forward(input),
             PbChem::ThreePointTwo => self.three_two.forward(input),
             PbChem::Revio => self.revio.forward(input),
         };
-        // allow fake predictions for testing speed of other parts of the code
-        if opts.fake {
-            return vec![0.0; count];
-        }
         forward
             .into_data()
             .convert()

--- a/src/main.rs
+++ b/src/main.rs
@@ -82,6 +82,9 @@ pub fn main() -> Result<(), Error> {
         Some(Commands::Fire(fire_opts)) => {
             subcommands::fire::add_fire_to_bam(fire_opts)?;
         }
+        Some(Commands::Qc(qc_opts)) => {
+            subcommands::qc::run_qc(qc_opts)?;
+        }
         Some(Commands::Footprint(footprint_opts)) => {
             subcommands::footprint::start_finding_footprints(footprint_opts)?;
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -69,7 +69,7 @@ pub fn main() -> Result<(), Error> {
             {
                 let mut tch_threads = 1;
                 if args.global.threads >= 16 {
-                    tch_threads = 2;
+                    tch_threads = 1;
                     //set_rayon_threads(args.global.threads / tch_threads + 1)?;
                     log::info!(
                         "Setting tch threads to: {} and rayon threads to: {}",

--- a/src/main.rs
+++ b/src/main.rs
@@ -67,19 +67,10 @@ pub fn main() -> Result<(), Error> {
             );
             #[cfg(feature = "tch")]
             {
-                let mut tch_threads = 1;
-                if args.global.threads >= 16 {
-                    tch_threads = 1;
-                    //set_rayon_threads(args.global.threads / tch_threads + 1)?;
-                    log::info!(
-                        "Setting tch threads to: {} and rayon threads to: {}",
-                        tch_threads,
-                        args.global.threads / tch_threads + 1
-                    );
-                }
-                // setting this to 1 since I do paralyzation via processing multiple reads
-                tch::set_num_threads(tch_threads as i32);
-                tch::set_num_interop_threads(tch_threads as i32);
+                // one threads works best for CPU inference performance
+                // with rayon handling the parallelism using multiple reads
+                tch::set_num_threads(1);
+                tch::set_num_interop_threads(1);
             }
             subcommands::predict_m6a::read_bam_into_fiberdata(predict_m6a_opts);
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -70,7 +70,7 @@ pub fn main() -> Result<(), Error> {
                 let mut tch_threads = 1;
                 if args.global.threads >= 16 {
                     tch_threads = args.global.threads / 16 + 1;
-                    set_rayon_threads(args.global.threads / tch_threads + 1)?;
+                    //set_rayon_threads(args.global.threads / tch_threads + 1)?;
                     log::info!(
                         "Setting tch threads to: {} and rayon threads to: {}",
                         tch_threads,

--- a/src/main.rs
+++ b/src/main.rs
@@ -66,7 +66,7 @@ pub fn main() -> Result<(), Error> {
                 "\n{}\n\t{}\n\t{}\n", 
                 "WARNING: m6A predictions are slower without the pytorch backend.".bright_yellow().bold(),
                 "Consider recompiling via cargo with: `--all-features`.",
-                "For detailed instructions see: https://fiberseq.github.io/fibertools-rs/INSTALL.html."
+                "For detailed instructions see: https://fiberseq.github.io/fibertools/install.html."
             );
             subcommands::predict_m6a::read_bam_into_fiberdata(predict_m6a_opts);
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -69,7 +69,7 @@ pub fn main() -> Result<(), Error> {
             {
                 let mut tch_threads = 1;
                 if args.global.threads >= 16 {
-                    tch_threads = args.global.threads / 16 + 1;
+                    tch_threads = 2;
                     //set_rayon_threads(args.global.threads / tch_threads + 1)?;
                     log::info!(
                         "Setting tch threads to: {} and rayon threads to: {}",

--- a/src/main.rs
+++ b/src/main.rs
@@ -71,7 +71,7 @@ pub fn main() -> Result<(), Error> {
                 if args.global.threads >= 16 {
                     tch_threads = args.global.threads / 16 + 1;
                     set_rayon_threads(args.global.threads / tch_threads + 1)?;
-                    log::debug!(
+                    log::info!(
                         "Setting tch threads to: {} and rayon threads to: {}",
                         tch_threads,
                         args.global.threads / tch_threads + 1

--- a/src/subcommands.rs
+++ b/src/subcommands.rs
@@ -16,5 +16,7 @@ pub mod footprint;
 pub mod pileup;
 /// m6A prediction
 pub mod predict_m6a;
+/// Collect QC metrics
+pub mod qc;
 /// Remove base modifications from a bam record
 pub mod strip_basemods;

--- a/src/subcommands/predict_m6a.rs
+++ b/src/subcommands/predict_m6a.rs
@@ -497,15 +497,19 @@ pub fn read_bam_into_fiberdata(predict_options: &mut PredictM6AOptions) {
     log::info!("Using Candle for ML backend.");
 
     // switch to the internal predict options
-    let predict_options: PredictOptions<MlBackend> = PredictOptions::new(
-        predict_options.keep,
-        predict_options.force_min_ml_score,
-        predict_options.all_calls,
-        find_pb_polymerase(&header),
-        predict_options.batch_size,
-        predict_options.nuc.clone(),
-        predict_options.fake,
-    );
+    let mut predict_options_vec = vec![];
+    for _ in 0..predict_options.batch_size {
+        let predict_options: PredictOptions<MlBackend> = PredictOptions::new(
+            predict_options.keep,
+            predict_options.force_min_ml_score,
+            predict_options.all_calls,
+            find_pb_polymerase(&header),
+            predict_options.batch_size,
+            predict_options.nuc.clone(),
+            predict_options.fake,
+        );
+        predict_options_vec.push(predict_options);
+    }
 
     // read in bam data
     let bam_chunk_iter = BamChunk::new(bam.records(), None);
@@ -515,7 +519,13 @@ pub fn read_bam_into_fiberdata(predict_options: &mut PredictM6AOptions) {
         let number_of_reads_with_predictions = chunk
             .par_iter_mut()
             .chunks(predict_options.batch_size)
-            .map(|recs| predict_options.predict_m6a_on_records(recs))
+            .map(|recs| {
+                let mut sum = 0;
+                for (rec, predict_options) in recs.into_iter().zip(predict_options_vec.iter()) {
+                    sum += predict_options.predict_m6a_on_records(vec![rec]);
+                }
+                sum
+            })
             .sum::<usize>() as f32;
 
         let frac_called = number_of_reads_with_predictions / chunk.len() as f32;

--- a/src/subcommands/predict_m6a.rs
+++ b/src/subcommands/predict_m6a.rs
@@ -69,13 +69,13 @@ where
             keep,
             min_ml_score,
             all_calls,
-            polymerase,
+            polymerase: polymerase.clone(),
             batch_size,
             map,
             model: vec![],
             min_ml: 0,
             nuc_opts,
-            burn_models: m6a_burn::BurnModels::new(),
+            burn_models: m6a_burn::BurnModels::new(&polymerase),
             fake,
         };
         options.add_model().expect("Error loading model");

--- a/src/subcommands/predict_m6a.rs
+++ b/src/subcommands/predict_m6a.rs
@@ -43,6 +43,7 @@ where
     pub min_ml: u8,
     pub nuc_opts: cli::NucleosomeParameters,
     pub burn_models: m6a_burn::BurnModels<B>,
+    pub fake: bool,
 }
 
 impl<B> PredictOptions<B>
@@ -57,6 +58,7 @@ where
         polymerase: PbChem,
         batch_size: usize,
         nuc_opts: cli::NucleosomeParameters,
+        fake: bool,
     ) -> Self {
         // set up a precision table
         let mut map = BTreeMap::new();
@@ -74,6 +76,7 @@ where
             min_ml: 0,
             nuc_opts,
             burn_models: m6a_burn::BurnModels::new(),
+            fake,
         };
         options.add_model().expect("Error loading model");
         options
@@ -501,6 +504,7 @@ pub fn read_bam_into_fiberdata(predict_options: &mut PredictM6AOptions) {
         find_pb_polymerase(&header),
         predict_options.batch_size,
         predict_options.nuc.clone(),
+        predict_options.fake,
     );
 
     // read in bam data

--- a/src/subcommands/qc.rs
+++ b/src/subcommands/qc.rs
@@ -1,0 +1,108 @@
+use crate::cli::QcOpts;
+use crate::fiber;
+use anyhow::Result;
+use ordered_float::OrderedFloat;
+use std::collections::HashMap;
+
+pub struct QcStats {
+    pub fiber_count: i64,
+    // hashmap that stores lengths of fibers
+    pub fiber_lengths: HashMap<i64, i64>,
+    // length of msps
+    pub msp_lengths: HashMap<i64, i64>,
+    // lengths of nucleosomes
+    pub nuc_lengths: HashMap<i64, i64>,
+    // number of ccs passes per read
+    pub ccs_passes: HashMap<OrderedFloat<f32>, i64>,
+    /// m6as per read   
+    pub m6a_count: HashMap<i64, i64>,
+    // m6as over total AT count
+    pub m6a_ratio: HashMap<OrderedFloat<f32>, i64>,
+    // add rq to stats
+    pub rq: HashMap<OrderedFloat<f32>, i64>,
+}
+
+impl QcStats {
+    pub fn new() -> Self {
+        Self {
+            fiber_count: 0,
+            fiber_lengths: HashMap::new(),
+            msp_lengths: HashMap::new(),
+            nuc_lengths: HashMap::new(),
+            ccs_passes: HashMap::new(),
+            m6a_count: HashMap::new(),
+            m6a_ratio: HashMap::new(),
+            rq: HashMap::new(),
+        }
+    }
+
+    pub fn add_read_to_stats(&mut self, fiber: &fiber::FiberseqData) {
+        self.full_read_stats(fiber);
+        self.add_m6a_stats(fiber);
+        Self::add_range_lengths(&mut self.msp_lengths, &fiber.msp);
+        Self::add_range_lengths(&mut self.nuc_lengths, &fiber.nuc);
+    }
+
+    fn full_read_stats(&mut self, fiber: &fiber::FiberseqData) {
+        self.fiber_count += 1;
+        self.fiber_lengths
+            .entry(fiber.record.seq_len() as i64)
+            .and_modify(|e| *e += 1)
+            .or_insert(1);
+        self.ccs_passes
+            .entry(OrderedFloat(fiber.ec))
+            .and_modify(|e| *e += 1)
+            .or_insert(1);
+        if let Some(rq) = fiber.get_rq() {
+            self.rq
+                .entry(OrderedFloat(rq))
+                .and_modify(|e| *e += 1)
+                .or_insert(1);
+        }
+    }
+
+    fn add_m6a_stats(&mut self, fiber: &fiber::FiberseqData) {
+        let m6a_count = fiber.m6a.starts.len() as i64;
+        self.m6a_count
+            .entry(m6a_count)
+            .and_modify(|e| *e += 1)
+            .or_insert(1);
+
+        // now get the ratio
+        let total_at = fiber
+            .record
+            .seq()
+            .as_bytes()
+            .iter()
+            .filter(|&b| *b == b'A' || *b == b'T')
+            .count();
+
+        let ratio = m6a_count as f32 / total_at as f32;
+        self.m6a_ratio
+            .entry(OrderedFloat(ratio))
+            .and_modify(|e| *e += 1)
+            .or_insert(1);
+    }
+
+    fn add_range_lengths(hashmap: &mut HashMap<i64, i64>, range: &crate::utils::bamranges::Ranges) {
+        for r in range.lengths.iter().flatten() {
+            hashmap.entry(*r).and_modify(|e| *e += 1).or_insert(1);
+        }
+    }
+}
+
+impl Default for QcStats {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+pub fn run_qc(opts: &mut QcOpts) -> Result<(), anyhow::Error> {
+    let mut bam = opts.input.bam_reader();
+    let mut stats = QcStats::default();
+
+    for fiber in opts.input.fibers(&mut bam) {
+        stats.add_read_to_stats(&fiber);
+    }
+    Ok(())
+}

--- a/src/subcommands/qc.rs
+++ b/src/subcommands/qc.rs
@@ -7,6 +7,7 @@ use ordered_float::OrderedFloat;
 use std::collections::HashMap;
 use std::io::Write;
 
+// set the precision of the floats to be saved and printed
 fn my_ordered_float(f: f32) -> OrderedFloat<f32> {
     OrderedFloat((f * 100_000.0).round() / 100_000.0)
 }

--- a/src/subcommands/qc.rs
+++ b/src/subcommands/qc.rs
@@ -1,8 +1,11 @@
 use crate::cli::QcOpts;
 use crate::fiber;
+use crate::utils::bio_io;
 use anyhow::Result;
+use itertools::Itertools;
 use ordered_float::OrderedFloat;
 use std::collections::HashMap;
+use std::io::Write;
 
 pub struct QcStats {
     pub fiber_count: i64,
@@ -18,6 +21,8 @@ pub struct QcStats {
     pub m6a_count: HashMap<i64, i64>,
     // m6as over total AT count
     pub m6a_ratio: HashMap<OrderedFloat<f32>, i64>,
+    // cpg count
+    pub cpg_count: HashMap<i64, i64>,
     // add rq to stats
     pub rq: HashMap<OrderedFloat<f32>, i64>,
 }
@@ -32,13 +37,14 @@ impl QcStats {
             ccs_passes: HashMap::new(),
             m6a_count: HashMap::new(),
             m6a_ratio: HashMap::new(),
+            cpg_count: HashMap::new(),
             rq: HashMap::new(),
         }
     }
 
     pub fn add_read_to_stats(&mut self, fiber: &fiber::FiberseqData) {
         self.full_read_stats(fiber);
-        self.add_m6a_stats(fiber);
+        self.add_basemod_stats(fiber);
         Self::add_range_lengths(&mut self.msp_lengths, &fiber.msp);
         Self::add_range_lengths(&mut self.nuc_lengths, &fiber.nuc);
     }
@@ -61,7 +67,7 @@ impl QcStats {
         }
     }
 
-    fn add_m6a_stats(&mut self, fiber: &fiber::FiberseqData) {
+    fn add_basemod_stats(&mut self, fiber: &fiber::FiberseqData) {
         let m6a_count = fiber.m6a.starts.len() as i64;
         self.m6a_count
             .entry(m6a_count)
@@ -76,10 +82,15 @@ impl QcStats {
             .iter()
             .filter(|&b| *b == b'A' || *b == b'T')
             .count();
-
         let ratio = m6a_count as f32 / total_at as f32;
         self.m6a_ratio
             .entry(OrderedFloat(ratio))
+            .and_modify(|e| *e += 1)
+            .or_insert(1);
+
+        // cpg count
+        self.cpg_count
+            .entry(fiber.cpg.starts.len() as i64)
             .and_modify(|e| *e += 1)
             .or_insert(1);
     }
@@ -88,6 +99,43 @@ impl QcStats {
         for r in range.lengths.iter().flatten() {
             hashmap.entry(*r).and_modify(|e| *e += 1).or_insert(1);
         }
+    }
+
+    /// write the output to stdout
+    pub fn write(&self, out: &mut Box<dyn Write>) -> Result<(), anyhow::Error> {
+        // write the header
+        out.write_all(b"statistic\tvalue\tcount\n")?;
+        // write the integers
+        for x in &[
+            (&self.fiber_lengths, "fiber_lengths"),
+            (&self.msp_lengths, "msp_lengths"),
+            (&self.nuc_lengths, "nuc_lengths"),
+            (&self.m6a_count, "m6a_count"),
+            (&self.cpg_count, "cpg_count"),
+        ] {
+            out.write_all(Self::hashmap_to_string(x.0, x.1).as_bytes())?;
+        }
+        // write the floats
+        for f in &[
+            (&self.ccs_passes, "ccs_passes"),
+            (&self.rq, "rq"),
+            (&self.m6a_ratio, "m6a_ratio"),
+        ] {
+            out.write_all(Self::hashmap_to_string(f.0, f.1).as_bytes())?;
+        }
+
+        Ok(())
+    }
+
+    fn hashmap_to_string<T>(hashmap: &HashMap<T, i64>, name: &str) -> String
+    where
+        T: std::fmt::Display + std::hash::Hash + Eq + std::cmp::Ord,
+    {
+        let mut out = "".to_string();
+        for (k, v) in hashmap.iter().sorted() {
+            out += &format!("{}\t{}\t{}\n", name, k, v);
+        }
+        out
     }
 }
 
@@ -100,9 +148,10 @@ impl Default for QcStats {
 pub fn run_qc(opts: &mut QcOpts) -> Result<(), anyhow::Error> {
     let mut bam = opts.input.bam_reader();
     let mut stats = QcStats::default();
-
     for fiber in opts.input.fibers(&mut bam) {
         stats.add_read_to_stats(&fiber);
     }
+    let mut out = bio_io::writer(&opts.out)?;
+    stats.write(&mut out)?;
     Ok(())
 }

--- a/src/subcommands/qc.rs
+++ b/src/subcommands/qc.rs
@@ -118,7 +118,7 @@ impl QcStats {
         // write the floats
         for f in &[
             (&self.ccs_passes, "ccs_passes"),
-            (&self.rq, "rq"),
+            (&self.rq, "read_quality"),
             (&self.m6a_ratio, "m6a_ratio"),
         ] {
             out.write_all(Self::hashmap_to_string(f.0, f.1).as_bytes())?;

--- a/src/subcommands/qc.rs
+++ b/src/subcommands/qc.rs
@@ -24,6 +24,8 @@ pub struct QcStats {
     pub nuc_count: HashMap<i64, i64>,
     // lengths of nucleosomes
     pub nuc_lengths: HashMap<i64, i64>,
+    // read_length per nucleosome
+    pub read_length_per_nuc: HashMap<OrderedFloat<f32>, i64>,
     // number of ccs passes per read
     pub ccs_passes: HashMap<OrderedFloat<f32>, i64>,
     /// m6as per read   
@@ -45,6 +47,7 @@ impl QcStats {
             msp_lengths: HashMap::new(),
             nuc_count: HashMap::new(),
             nuc_lengths: HashMap::new(),
+            read_length_per_nuc: HashMap::new(),
             ccs_passes: HashMap::new(),
             m6a_count: HashMap::new(),
             m6a_ratio: HashMap::new(),
@@ -68,6 +71,12 @@ impl QcStats {
             .or_insert(1);
         self.msp_count
             .entry(fiber.msp.starts.len() as i64)
+            .and_modify(|e| *e += 1)
+            .or_insert(1);
+        // read length per nucleosome
+        let read_length = fiber.record.seq_len() as f32 / fiber.nuc.starts.len() as f32;
+        self.read_length_per_nuc
+            .entry(my_ordered_float(read_length))
             .and_modify(|e| *e += 1)
             .or_insert(1);
     }
@@ -142,6 +151,7 @@ impl QcStats {
         }
         // write the floats
         for f in &[
+            (&self.read_length_per_nuc, "read_length_per_nuc"),
             (&self.ccs_passes, "ccs_passes"),
             (&self.rq, "read_quality"),
             (&self.m6a_ratio, "m6a_ratio"),

--- a/src/subcommands/qc.rs
+++ b/src/subcommands/qc.rs
@@ -139,11 +139,11 @@ impl QcStats {
         out.write_all(b"statistic\tvalue\tcount\n")?;
         // write the integers
         for x in &[
-            (&self.fiber_lengths, "fiber_lengths"),
+            (&self.fiber_lengths, "fiber_length"),
             (&self.msp_count, "msp_count"),
-            (&self.msp_lengths, "msp_lengths"),
+            (&self.msp_lengths, "msp_length"),
             (&self.nuc_count, "nuc_count"),
-            (&self.nuc_lengths, "nuc_lengths"),
+            (&self.nuc_lengths, "nuc_length"),
             (&self.m6a_count, "m6a_count"),
             (&self.cpg_count, "cpg_count"),
         ] {

--- a/src/subcommands/qc.rs
+++ b/src/subcommands/qc.rs
@@ -7,6 +7,10 @@ use ordered_float::OrderedFloat;
 use std::collections::HashMap;
 use std::io::Write;
 
+fn my_ordered_float(f: f32) -> OrderedFloat<f32> {
+    OrderedFloat((f * 100_000.0).round() / 100_000.0)
+}
+
 pub struct QcStats {
     pub fiber_count: i64,
     // hashmap that stores lengths of fibers
@@ -56,12 +60,12 @@ impl QcStats {
             .and_modify(|e| *e += 1)
             .or_insert(1);
         self.ccs_passes
-            .entry(OrderedFloat(fiber.ec))
+            .entry(my_ordered_float(fiber.ec))
             .and_modify(|e| *e += 1)
             .or_insert(1);
         if let Some(rq) = fiber.get_rq() {
             self.rq
-                .entry(OrderedFloat(rq))
+                .entry(my_ordered_float(rq))
                 .and_modify(|e| *e += 1)
                 .or_insert(1);
         }
@@ -84,8 +88,8 @@ impl QcStats {
             .count();
         let ratio = m6a_count as f32 / total_at as f32;
         self.m6a_ratio
-            .entry(OrderedFloat(ratio))
-            .and_modify(|e| *e += 1)
+            .entry(my_ordered_float(ratio))
+            .and_modify(|e: &mut i64| *e += 1)
             .or_insert(1);
 
         // cpg count

--- a/src/utils/bio_io.rs
+++ b/src/utils/bio_io.rs
@@ -199,7 +199,7 @@ impl<'a> BamChunk<'a> {
     pub fn new(bam: bam::Records<'a, bam::Reader>, chunk_size: Option<usize>) -> Self {
         let chunk_size = std::cmp::min(
             chunk_size.unwrap_or_else(|| current_num_threads() * 100),
-            2_000,
+            1_000,
         );
         let bar = no_length_progress_bar();
         Self {

--- a/src/utils/bio_io.rs
+++ b/src/utils/bio_io.rs
@@ -199,7 +199,7 @@ impl<'a> BamChunk<'a> {
     pub fn new(bam: bam::Records<'a, bam::Reader>, chunk_size: Option<usize>) -> Self {
         let chunk_size = std::cmp::min(
             chunk_size.unwrap_or_else(|| current_num_threads() * 100),
-            1_000,
+            2_000,
         );
         let bar = no_length_progress_bar();
         Self {

--- a/src/utils/bio_io.rs
+++ b/src/utils/bio_io.rs
@@ -197,7 +197,10 @@ pub struct BamChunk<'a> {
 
 impl<'a> BamChunk<'a> {
     pub fn new(bam: bam::Records<'a, bam::Reader>, chunk_size: Option<usize>) -> Self {
-        let chunk_size = chunk_size.unwrap_or_else(|| current_num_threads() * 100);
+        let chunk_size = std::cmp::min(
+            chunk_size.unwrap_or_else(|| current_num_threads() * 100),
+            1_000,
+        );
         let bar = no_length_progress_bar();
         Self {
             bam,

--- a/src/utils/nucleosome.rs
+++ b/src/utils/nucleosome.rs
@@ -199,6 +199,7 @@ pub fn add_nucleosomes_to_record(
     record.remove_aux(b"nl").unwrap_or(());
     record.remove_aux(b"as").unwrap_or(());
     record.remove_aux(b"al").unwrap_or(());
+    record.remove_aux(b"aq").unwrap_or(());
 
     let nucs = if options.allowed_m6a_skips < 0 {
         find_nucleosomes(m6a, options)

--- a/tests/basemods.rs
+++ b/tests/basemods.rs
@@ -1,6 +1,5 @@
 use env_logger::{Builder, Target};
 use fibertools_rs::utils::basemods::*;
-use log;
 use rust_htslib::{bam, bam::Read};
 
 #[test]
@@ -11,7 +10,7 @@ fn test_mods_do_not_change() {
         .target(Target::Stderr)
         .filter(None, log::LevelFilter::Debug)
         .init();
-    let mut bam = bam::Reader::from_path(&"tests/data/all.bam").unwrap();
+    let mut bam = bam::Reader::from_path("tests/data/all.bam").unwrap();
     for rec in bam.records() {
         let mut rec = rec.unwrap();
         let mods = BaseMods::new(&rec, 0);

--- a/tests/bio_io.rs
+++ b/tests/bio_io.rs
@@ -1,10 +1,9 @@
 use fibertools_rs::utils::bio_io;
-use log;
 use rust_htslib::{bam, bam::Read};
 
 #[test]
 pub fn test_msp_nuc_tags() {
-    let mut bam = bam::Reader::from_path(&"tests/data/all.bam").unwrap();
+    let mut bam = bam::Reader::from_path("tests/data/all.bam").unwrap();
     for record in bam.records() {
         let record = record.unwrap();
         let _n_s = bio_io::get_u32_tag(&record, b"ns");

--- a/tests/extract_test.rs
+++ b/tests/extract_test.rs
@@ -7,7 +7,7 @@ fn get_fiber_data_from_test_bam(bam_file: &str) -> Vec<fibertools_rs::fiber::Fib
     bam.records()
         .map(|r| {
             let record = r.unwrap();
-            
+
             fibertools_rs::fiber::FiberseqData::new(record, None, &FiberFilters::default())
         })
         .collect::<Vec<_>>()
@@ -43,7 +43,8 @@ fn test_many_msps() {
             .msp
             .starts
             .iter()
-            .flatten().copied()
+            .flatten()
+            .copied()
             .chain(fiber_data.msp.ends.iter().flatten().map(|&x| x - 1))
             .collect::<Vec<_>>();
         eprintln!("m6a: {:?}", m6a);

--- a/tests/extract_test.rs
+++ b/tests/extract_test.rs
@@ -7,9 +7,8 @@ fn get_fiber_data_from_test_bam(bam_file: &str) -> Vec<fibertools_rs::fiber::Fib
     bam.records()
         .map(|r| {
             let record = r.unwrap();
-            let fiber_data =
-                fibertools_rs::fiber::FiberseqData::new(record, None, &FiberFilters::default());
-            fiber_data
+            
+            fibertools_rs::fiber::FiberseqData::new(record, None, &FiberFilters::default())
         })
         .collect::<Vec<_>>()
 }
@@ -44,8 +43,7 @@ fn test_many_msps() {
             .msp
             .starts
             .iter()
-            .flatten()
-            .map(|&x| x)
+            .flatten().copied()
             .chain(fiber_data.msp.ends.iter().flatten().map(|&x| x - 1))
             .collect::<Vec<_>>();
         eprintln!("m6a: {:?}", m6a);

--- a/tests/m6a_prediction_test.rs
+++ b/tests/m6a_prediction_test.rs
@@ -1,4 +1,3 @@
-use fibertools_rs;
 use fibertools_rs::utils::bio_io;
 use fibertools_rs::utils::input_bam::FiberFilters;
 use rust_htslib::bam::Reader;
@@ -25,7 +24,7 @@ fn run_prediction_and_count_qual(inbam: String) -> usize {
     let named_tmp_bam_out = NamedTempFile::new().unwrap();
     let out_str = named_tmp_bam_out.path().to_str().unwrap();
     let mut predict_options = fibertools_rs::cli::PredictM6AOptions::default();
-    predict_options.input.bam = inbam.clone();
+    predict_options.input.bam.clone_from(&inbam);
     predict_options.input.global.threads = 1;
     predict_options.out = out_str.to_string();
 


### PR DESCRIPTION
The idea is to create text histograms that can be used as inputs to plotting programs.

The current output idea is a text file that looks like:
```
statistic       value   count
fiber_lengths   1000     58
fiber_lengths   1001     100
...
read_quality   0.98   1001
...
m6a_ratio    0.06    1002
...
```

I'm adding a new stat that is the number of m6as in MSPs of specific sizes, whether that MSP is a FIRE element, and the number of times that was seen.
```
statistic       value   count
...
m6a_per_msp_size        1,1,false       4451629
m6a_per_msp_size        2,2,false       123829
m6a_per_msp_size        2,3,false       347430
m6a_per_msp_size        2,4,false       306585
m6a_per_msp_size        2,5,false       189577
m6a_per_msp_size        2,6,false       182797
m6a_per_msp_size        2,7,false       169225
...
```
This output is added when the option `--m6a-per-msp` is used. 

