### PR TITLE
Enable Revio model for Vega

### DIFF
--- a/src/utils/bio_io.rs
+++ b/src/utils/bio_io.rs
@@ -291,7 +291,7 @@ pub fn find_pb_polymerase(header: &bam::Header) -> PbChem {
             // regular 3.2
             ("102-194-100".to_string(), PbChem::ThreePointTwo),
             // Revio has kinetics most similar to 2.2
-            ("102-739-100".to_string(), PbChem::Revio)
+            ("102-739-100".to_string(), PbChem::Revio),
             // Vega currently using Revio chemistry
             ("103-426-500".to_string(), PbChem::Revio)
         ]);

--- a/src/utils/bio_io.rs
+++ b/src/utils/bio_io.rs
@@ -292,6 +292,8 @@ pub fn find_pb_polymerase(header: &bam::Header) -> PbChem {
             ("102-194-100".to_string(), PbChem::ThreePointTwo),
             // Revio has kinetics most similar to 2.2
             ("102-739-100".to_string(), PbChem::Revio)
+            // Vega currently using Revio chemistry
+            ("103-426-500".to_string(), PbChem::Revio)
         ]);
     }
     lazy_static! {


### PR DESCRIPTION
Edited bio_io.rs to accept the Vega binding kit number and apply Revio model.

I tested that this fix runs and passes tests.