### PR TITLE
fix: --skip-no-m6a skips all reads when MSP annotations are missing

### DIFF
--- a/src/subcommands/fire.rs
+++ b/src/subcommands/fire.rs
@@ -72,20 +72,25 @@ pub fn add_fire_to_bam(fire_opts: &mut FireOptions) -> Result<(), anyhow::Error>
                 let n_msps = rec.msp.annotations.len();
                 if fire_opts.skip_no_m6a || fire_opts.min_msp > 0 || fire_opts.min_ave_msp_size > 0
                 {
-                    // skip no calls
-                    if rec.m6a.annotations.is_empty() || n_msps == 0 {
+                    // skip reads with no m6a calls
+                    if fire_opts.skip_no_m6a && rec.m6a.annotations.is_empty() {
                         skip_because_no_m6a += 1;
                         continue;
                     }
-                    //let max_msp_len = *rec.msp.lengths.iter().flatten().max().unwrap_or(&0);
                     if n_msps < fire_opts.min_msp {
                         skip_because_num_msp += 1;
                         continue;
                     }
-                    let ave_msp_size = rec.msp.lengths().iter().sum::<i64>() / n_msps as i64;
-                    if ave_msp_size < fire_opts.min_ave_msp_size {
-                        skip_because_ave_msp_length += 1;
-                        continue;
+                    if fire_opts.min_ave_msp_size > 0 {
+                        if n_msps == 0 {
+                            skip_because_ave_msp_length += 1;
+                            continue;
+                        }
+                        let ave_msp_size = rec.msp.lengths().iter().sum::<i64>() / n_msps as i64;
+                        if ave_msp_size < fire_opts.min_ave_msp_size {
+                            skip_because_ave_msp_length += 1;
+                            continue;
+                        }
                     }
                 }
                 out.write(&rec.record)?;


### PR DESCRIPTION
## Summary
- The `--skip-no-m6a` flag in `ft fire` incorrectly skipped all reads when the BAM had valid m6A calls (MM/ML tags) but no pre-computed MSP annotations (`as` tag)
- The skip condition `rec.m6a.annotations.is_empty() || n_msps == 0` conflated "no m6A" with "no MSPs", causing all ONT reads (which have m6A from dorado but no fiberseq MSP tags) to be skipped
- Now `--skip-no-m6a` only checks m6A presence, MSP count is checked separately by `--min-msp`, and the division-by-zero guard for average MSP size is scoped to when `--min-ave-msp-size > 0`

Fixes #100

## Test plan
- [x] Verified with the reporter's test BAM: before fix 0/4 reads written, after fix 4/4 reads written
- [x] All existing tests pass (`cargo test`)
- [x] Test with PacBio fiberseq data to confirm no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)