### PR TITLE
fix(docs): drop unmaintained m2r2 to unbreak readthedocs build

### DIFF
--- a/py-ft/docs/conf.py
+++ b/py-ft/docs/conf.py
@@ -33,13 +33,10 @@ extensions = [
     "sphinx_rtd_theme",
     "sphinx.ext.intersphinx",
     # "edit_on_github",
-    "m2r2",
-    # include markdown
     "nbsphinx",
 ]
 
-# source_suffix = '.rst'
-source_suffix = [".rst", ".md", ".py"]
+source_suffix = [".rst", ".py"]
 
 templates_path = ["_templates"]
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]

--- a/py-ft/docs/requirements.txt
+++ b/py-ft/docs/requirements.txt
@@ -1,4 +1,3 @@
-m2r2
 sphinx_bootstrap_theme
 sphinx<7.0.0
 sphinx-autodoc-typehints


### PR DESCRIPTION
## Summary

- RTD builds have been failing with `Could not import extension m2r2 (exception: No module named 'pkg_resources')`. `m2r2` imports `pkg_resources` at module load, which newer setuptools/Python environments no longer ship by default.
- `m2r2` was registered as a Sphinx extension and `.md` was in `source_suffix`, but **no markdown files are included anywhere** in `py-ft/docs/` (no `mdinclude`, no `.. include:: *.md`), so the extension was dead weight.
- Removing `m2r2` from `extensions` and `requirements.txt` eliminates the failure with no functional loss.

Reference failing build (commit `83d5eec`): https://app.readthedocs.org/projects/py-ft/builds/32435915/

## Test plan

- [ ] RTD PR-preview build succeeds on this PR
- [ ] Rendered docs still show `index.rst`, `api.rst`, and the vignette notebooks correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)