### PR TITLE
fix: leading soft clips double-counted in pyMA liftover (python package only; Rust/ft unaffected)

### DIFF
--- a/molecular-annotation/python/molecular_annotation/pysam_utils.py
+++ b/molecular-annotation/python/molecular_annotation/pysam_utils.py
@@ -148,16 +148,10 @@ def _extract_aligned_blocks(
     query_pos = 0
     ref_pos = record.reference_start
 
-    # Handle leading hard/soft clips
-    for op, length in record.cigartuples:
-        if op == BAM_CHARD_CLIP:
-            continue  # Hard clips don't consume query
-        elif op == BAM_CSOFT_CLIP:
-            query_pos += length
-        else:
-            break
-
-    # Process CIGAR operations
+    # Process CIGAR operations. Leading soft clips are consumed by the
+    # BAM_CSOFT_CLIP branch below exactly once — a separate pre-scan would
+    # double-count them and shift every query coordinate right by the clip
+    # length.
     for op, length in record.cigartuples:
         if op in (BAM_CMATCH, BAM_CEQUAL, BAM_CDIFF):
             # Aligned block
@@ -174,7 +168,7 @@ def _extract_aligned_blocks(
             # Deletion/skip - consumes reference only
             ref_pos += length
         elif op == BAM_CSOFT_CLIP:
-            # Soft clip at end - consumes query only
+            # Soft clip (leading or trailing) - consumes query only
             query_pos += length
         # Hard clips and padding don't consume either
 

--- a/molecular-annotation/python/tests/test_molecular_annotation.py
+++ b/molecular-annotation/python/tests/test_molecular_annotation.py
@@ -663,6 +663,51 @@ class TestMmMl:
     not _FIBERSEQ_BAM.exists(),
     reason="fiber-seq BAM fixture only present inside the fibertools-rs repo",
 )
+
+class TestAlignedBlocks:
+    """Liftover block extraction from CIGAR strings."""
+
+    def _record(self, pysam, cigar, seq_len, ref_start=1000):
+        header = pysam.AlignmentHeader.from_dict(
+            {"SQ": [{"SN": "chr1", "LN": 100000}]}
+        )
+        r = pysam.AlignedSegment(header)
+        r.query_name = "read"
+        r.query_sequence = "A" * seq_len
+        r.reference_id = 0
+        r.reference_start = ref_start
+        r.cigarstring = cigar
+        return r
+
+    def test_leading_soft_clip_not_double_counted(self):
+        """A leading soft clip must shift query coords by its length exactly
+        once; the old pre-scan double-counted it, shifting every liftover
+        right by the clip length."""
+        pysam = pytest.importorskip("pysam")
+        from molecular_annotation.pysam_utils import _extract_aligned_blocks
+
+        r = self._record(pysam, "10S90M", 100)
+        assert _extract_aligned_blocks(r) == [((10, 100), (1000, 1090))]
+
+    def test_clips_and_indels(self):
+        pysam = pytest.importorskip("pysam")
+        from molecular_annotation.pysam_utils import _extract_aligned_blocks
+
+        # hard clips consume nothing; trailing soft clip consumes query only
+        r = self._record(pysam, "5H10S40M2D40M10S5H", 100)
+        assert _extract_aligned_blocks(r) == [
+            ((10, 50), (1000, 1040)),
+            ((50, 90), (1042, 1082)),
+        ]
+
+    def test_pure_match_unchanged(self):
+        pysam = pytest.importorskip("pysam")
+        from molecular_annotation.pysam_utils import _extract_aligned_blocks
+
+        r = self._record(pysam, "100M", 100)
+        assert _extract_aligned_blocks(r) == [((0, 100), (1000, 1100))]
+
+
 class TestRealFixtures:
     """End-to-end tests against a real fiber-seq BAM (fibertools-rs all.bam).
 


### PR DESCRIPTION
**Scope: the `molecular-annotation` python package only.** The Rust crate and the `ft` CLI are unaffected — they delegate to rust-htslib's `aligned_block_pairs`, which advances the query position on soft clips exactly once inside its single CIGAR walk (verified against the rust-htslib 0.46 source). The FIRE pipeline is likewise unaffected.

The bug: the pysam reimplementation `_extract_aligned_blocks` (introduced with pyMA in #118, shipped in pyMA 0.1.0) pre-scanned leading clips to advance `query_pos`, then the main CIGAR loop counted the same leading soft clip again — shifting all query↔reference liftover coordinates right by the clip length for any read with a leading soft clip (`10S90M` gave query block `(20, 110)` instead of `(10, 100)`). Silent coordinate corruption for pyMA users; the previous tests only used pure-match CIGARs.

The fix deletes the pre-scan (the main loop handles clips exactly once, matching rust-htslib) and adds CIGAR regression tests (`10S90M`, `5H10S40M2D40M10S5H`, `100M`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)