### PR TITLE
fix: make the Read the Docs (py-ft) build independent of the pyft Rust build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,16 +8,12 @@ sphinx:
 
 build:
   os: "ubuntu-22.04"
-  apt_packages:
-    - cmake
   tools:
     python: "3.10"
-    rust: "latest"
 
+# Only install the docs requirements. Do NOT `pip install ./py-ft`: building
+# the pyft Rust extension fails on Read the Docs, and the docs build does not
+# need it -- conf.py stubs the compiled module and mocks runtime deps instead.
 python:
   install:
     - requirements: py-ft/docs/requirements.txt
-    - method: pip
-      path: ./py-ft
-#conda:
-#    environment: py-ft/docs/environment.yml

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,6 +10,18 @@ build:
   os: "ubuntu-22.04"
   tools:
     python: "3.10"
+  jobs:
+    post_checkout:
+      # For pull-request builds only, cancel the build when nothing that
+      # affects the py-ft docs changed. Exit code 183 is Read the Docs'
+      # special "cancel build" code: the build stops immediately and the PR
+      # check is reported as succeeded rather than failed.
+      # https://docs.readthedocs.com/platform/stable/guides/build/skip-build.html
+      - |
+        if [ "$READTHEDOCS_VERSION_TYPE" = "external" ] && git diff --quiet origin/main -- py-ft/ molecular-annotation/python/ .readthedocs.yaml;
+        then
+          exit 183;
+        fi
 
 # Only install the docs requirements. Do NOT `pip install ./py-ft`: building
 # the pyft Rust extension fails on Read the Docs, and the docs build does not

--- a/py-ft/docs/conf.py
+++ b/py-ft/docs/conf.py
@@ -5,12 +5,36 @@
 import os
 import re
 import sys
+import types
 
-# import sphinx
-# import sphinx.ext.autosummary as autosummary
-# sys.path.insert(0, os.path.abspath("../"))
-sys.path.insert(0, os.path.abspath("../python/pyft"))
-import pyft
+# The docs build must not depend on compiling the pyft Rust extension:
+# Read the Docs was failing in `pip install ./py-ft` because the native
+# (maturin/PyO3) build no longer compiles there. Instead, make the
+# pure-python sources importable directly and stub out the compiled
+# `pyft.pyft` submodule so `import pyft` works without the Rust build.
+sys.path.insert(0, os.path.abspath("../python"))  # provides the `pyft` package
+sys.path.insert(0, os.path.abspath("../python/pyft"))  # provides `utils` for api.rst
+
+_rust_stub = types.ModuleType("pyft.pyft")
+_rust_stub.__doc__ = (
+    "Compiled Rust extension of pyft (not available during the docs build)."
+)
+# `pyft/__init__.py` does `from .pyft import *` and then reads `pyft.__doc__`,
+# so the star-import must bind the name `pyft` to this stub.
+_rust_stub.pyft = _rust_stub
+_rust_stub.__all__ = ["pyft"]
+sys.modules["pyft.pyft"] = _rust_stub
+
+# Heavy runtime dependencies of pyft.utils/pyft.plot are not installed for the
+# docs build; mock them for autodoc.
+autodoc_mock_imports = [
+    "pandas",
+    "altair",
+    "polars",
+    "numpy",
+    "vegafusion",
+    "tqdm",
+]
 
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
@@ -18,8 +42,11 @@ import pyft
 project = "pyft"
 copyright = "2023, Mitchell R. Vollger"
 author = "Mitchell R. Vollger"
-version = pyft.__version__
-release = pyft.__version__
+
+# Read the version from py-ft/Cargo.toml instead of importing the built package.
+with open(os.path.join(os.path.dirname(__file__), "..", "Cargo.toml")) as _fh:
+    version = re.search(r'^version\s*=\s*"([^"]+)"', _fh.read(), re.M).group(1)
+release = version
 
 
 # -- General configuration ---------------------------------------------------
@@ -36,10 +63,14 @@ extensions = [
     "nbsphinx",
 ]
 
-source_suffix = [".rst", ".py"]
+source_suffix = [".rst"]
 
 templates_path = ["_templates"]
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
+
+# The vignette notebooks ship with saved outputs; never re-execute them during
+# the docs build (the compiled pyft extension is not available here).
+nbsphinx_execute = "never"
 
 
 # -- Options for HTML output -------------------------------------------------

--- a/py-ft/docs/requirements.txt
+++ b/py-ft/docs/requirements.txt
@@ -8,4 +8,5 @@ docutils==0.18.1
 setuptools
 nbsphinx
 pypandoc_binary
+ipython
 #sphinxawesome-theme

--- a/py-ft/docs/vignettes/index.rst
+++ b/py-ft/docs/vignettes/index.rst
@@ -7,5 +7,5 @@ Here are some examples of `pyft` in action:
    :maxdepth: 1
    :titlesonly:
 
-   basic-usage-examples.py
+   basic-usage-examples.ipynb
    centered-plot.ipynb


### PR DESCRIPTION
## Root cause

Every recent RTD build of the **py-ft** docs project (e.g. builds 34051704, 34054540, 34054557) fails in the same step:

```
python -m pip install --upgrade --upgrade-strategy only-if-needed --no-cache-dir ./py-ft
```

`.readthedocs.yaml` told RTD to `pip install ./py-ft`, which makes maturin compile the pyft PyO3 extension (and the whole fibertools-rs crate stack) on the RTD builder. That compile dies in `rust-htslib`:

```
error[E0308]: mismatched types
    --> rust-htslib-0.46.0/src/bgzf/mod.rs:264:17
 264 |                 buf.len() as u64,
     |                 ^^^^^^^^^^^^^^^^ expected `usize`, found `u64`
...
error: could not compile `rust-htslib` (lib) due to 10 previous errors
💥 maturin failed
ERROR: Failed building wheel for pyft
```

The docs only need `import pyft` to work for sphinx autodoc — compiling Rust on RTD buys nothing and breaks whenever the toolchain drifts (and the py-ft bindings currently don't compile against the crate anyway).

## What changed (docs/build config only)

- **`.readthedocs.yaml`**:
  - stop pip-installing `./py-ft`; drop the now-unneeded `rust` toolchain and `cmake` apt package; keep installing `py-ft/docs/requirements.txt`;
  - add RTD's documented conditional-skip step ([docs](https://docs.readthedocs.com/platform/stable/guides/build/skip-build.html)): for pull-request builds only (`READTHEDOCS_VERSION_TYPE = "external"`), a `build.jobs.post_checkout` command diffs against `origin/main` and exits with RTD's special code `183` when none of `py-ft/`, `molecular-annotation/python/`, or `.readthedocs.yaml` changed — RTD cancels the build immediately and reports the PR check as passing, so unrelated PRs no longer run the docs build at all.
- **`py-ft/docs/conf.py`**:
  - put `py-ft/python` on `sys.path` and register an in-memory stub for the compiled `pyft.pyft` submodule, so `import pyft` works without the Rust build (the stub binds the name `pyft` that `pyft/__init__.py`'s star-import relies on);
  - mock runtime deps (`pandas`, `altair`, `polars`, `numpy`, `vegafusion`, `tqdm`) via `autodoc_mock_imports`;
  - read `version` from `py-ft/Cargo.toml` instead of importing the built package;
  - `nbsphinx_execute = "never"` (the vignettes ship with saved outputs);
  - drop `".py"` from `source_suffix` — it made sphinx parse `conf.py` itself as a document (rst errors + "not in any toctree" warnings).
- **`py-ft/docs/requirements.txt`**: add `ipython` so the `ipython3` pygments lexer used by the notebook vignettes exists (kills 8 warnings).
- **`py-ft/docs/vignettes/index.rst`**: fix toctree typo `basic-usage-examples.py` → `.ipynb` (it only resolved before because `.py` was a registered source suffix).

No changes to any Rust/Python source, Cargo.toml, pyproject.toml, or other CI.

## Verification

Locally, in a fresh venv containing **only** `py-ft/docs/requirements.txt` (no pyft install, no Rust compilation):

```
python -m sphinx -T -b html -d doctrees -D language=en py-ft/docs out
```

builds successfully; `api.html` documents the `utils` functions, the vignettes render from saved outputs, and the version resolves to 0.3.0. The only remaining warnings are two rst issues inside the `utils.read_extract_all` docstring (pre-existing source-code docstring, non-fatal on RTD which has `fail_on_warning: false`).

On this PR, the `docs/readthedocs.org:py-ft` check **passed** on the first commit (build preview: https://py-ft--127.org.readthedocs.build/en/127/). The conditional-skip commit touches `.readthedocs.yaml` (a guarded path), so the check runs again for this PR rather than being skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)