### PR TITLE
ci: cache cargo artifacts, parallelize jobs and tests

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -11,13 +11,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
-          override: true
           components: rustfmt
 
       - name: Check format
@@ -27,33 +25,33 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
-          override: true
           components: clippy
+
+      - name: Cache cargo artifacts
+        uses: Swatinem/rust-cache@v2
 
       - name: Lint with clippy
         run: cargo clippy -p fibertools-rs
 
   Testing:
-    needs: Formatting
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo artifacts
+        uses: Swatinem/rust-cache@v2
 
       - name: Run test
-        run: cargo test -p fibertools-rs -- --test-threads=1
+        run: cargo test -p fibertools-rs
 
       - name: Run molecular-annotation tests
         run: cargo test -p molecular-annotation --features htslib


### PR DESCRIPTION
Four low-risk CI speedups: Swatinem/rust-cache in the compiling jobs (every run previously cold-compiled the full dep tree, including rust-htslib's C build, in both Linting and Testing); remove `needs: Formatting` so Testing runs in parallel instead of queueing behind a 10-second job; remove `--test-threads=1` (it dates to the original 2022 CI template, pre-dating the tempfile-based regression harness — current tests use unique tempfiles and read-only fixtures and run parallel-clean locally); replace the archived `actions-rs/toolchain` with `dtolnay/rust-toolchain` and bump checkout to v4. Expected effect: warm-cache Testing drops from ~7min to ~2–3min, and total PR wall-clock roughly halves. This PR's own run is the cache-priming (cold) run; the next PR shows the real timing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)