### PR TITLE
fix: a fully-filtered chunk no longer ends the fiber stream

### DIFF
--- a/src/utils/bio_io.rs
+++ b/src/utils/bio_io.rs
@@ -274,6 +274,8 @@ where
     //     * Otherwise, the next value is wrapped in `Some` and returned.
     // We use Self::Item in the return type, so we can change
     // the type without having to update the function signatures.
+    // Yields only non-empty chunks; `None` strictly means the underlying
+    // reader is exhausted. Consumers (FiberseqRecords) rely on this.
     fn next(&mut self) -> Option<Self::Item> {
         // update progress bar with results from previous iteration
         if self.pre_chunk_done > 0 {
@@ -285,23 +287,33 @@ where
         }
 
         let mut cur_vec = vec![];
-        for r in self.bam.by_ref().take(self.chunk_size) {
-            let r = r.unwrap();
-            let has_mm_and_ml = r.aux(b"MM").is_ok() && r.aux(b"ML").is_ok();
-            if has_mm_and_ml
-                && (r.cigar().leading_hardclips() > 0 || r.cigar().trailing_hardclips() > 0)
-            {
-                log::warn!(
-                    "Skipping read ({}) because it has been hard clipped and has ML and MM tags. This read will be excluded from calculations and any output.",
-                    String::from_utf8_lossy(r.qname())
-                );
-                continue;
+        // A pull whose records are ALL filtered out must not end the
+        // iterator (None means exhausted): keep pulling until a record
+        // survives or the underlying reader is truly out of records.
+        loop {
+            let mut pulled = 0usize;
+            for r in self.bam.by_ref().take(self.chunk_size) {
+                pulled += 1;
+                let r = r.unwrap();
+                let has_mm_and_ml = r.aux(b"MM").is_ok() && r.aux(b"ML").is_ok();
+                if has_mm_and_ml
+                    && (r.cigar().leading_hardclips() > 0 || r.cigar().trailing_hardclips() > 0)
+                {
+                    log::warn!(
+                        "Skipping read ({}) because it has been hard clipped and has ML and MM tags. This read will be excluded from calculations and any output.",
+                        String::from_utf8_lossy(r.qname())
+                    );
+                    continue;
+                }
+                // filter by bit flag
+                if r.flags() & self.bit_flag_filter != 0 {
+                    continue;
+                }
+                cur_vec.push(r);
             }
-            // filter by bit flag
-            if r.flags() & self.bit_flag_filter != 0 {
-                continue;
+            if !cur_vec.is_empty() || pulled < self.chunk_size {
+                break;
             }
-            cur_vec.push(r);
         }
 
         // extend progress bar

--- a/tests/fiber_stream.rs
+++ b/tests/fiber_stream.rs
@@ -1,0 +1,42 @@
+use fibertools_rs::fiber::FiberseqRecords;
+use fibertools_rs::utils::input_bam::FiberFilters;
+use rust_htslib::bam::{self, Read};
+
+/// A chunk whose records are all filtered out must not terminate the
+/// stream. Regression test: BamChunk::next used to return None (meaning
+/// "exhausted") whenever one pull of chunk_size records filtered to
+/// empty, silently dropping everything after e.g. a long run of
+/// secondary alignments under -F 256.
+#[test]
+fn stream_survives_a_fully_filtered_chunk() {
+    // chunk_size caps at 2,500; a longer run guarantees at least one
+    // all-filtered pull regardless of thread count.
+    const N_SECONDARY: usize = 3_000;
+    const N_PRIMARY: usize = 5;
+
+    let tmp = tempfile::NamedTempFile::with_suffix(".bam").unwrap();
+    let header = bam::Header::new();
+    {
+        let mut writer = bam::Writer::from_path(tmp.path(), &header, bam::Format::Bam).unwrap();
+        let mut rec = bam::Record::new();
+        rec.set(b"read", None, b"ACGTACGT", &[255u8; 8]);
+        rec.set_tid(-1);
+        rec.set_pos(-1);
+        for i in 0..(N_SECONDARY + N_PRIMARY) {
+            let flags = if i < N_SECONDARY { 0x100 } else { 0x4 };
+            rec.set_flags(flags);
+            writer.write(&rec).unwrap();
+        }
+    }
+
+    let mut bam = bam::Reader::from_path(tmp.path()).unwrap();
+    let filters = FiberFilters {
+        bit_flag: Some(0x100),
+        ..FiberFilters::default()
+    };
+    let n = FiberseqRecords::new(&mut bam, filters).count();
+    assert_eq!(
+        n, N_PRIMARY,
+        "reads after a fully-filtered chunk must still stream"
+    );
+}


### PR DESCRIPTION
## The bug

`BamChunk::next` pulls up to `chunk_size` (≤2,500) records and filters them inline (bit flag, hard-clip+MM/ML skip). When **every** record in one pull was filtered, it returned `None` — the iterator-exhausted signal — even with records remaining in the reader, and `FiberseqRecords::next` terminated the stream.

Concretely: `ft extract -F 256 in.bam` over a BAM containing a run of ≥2,500 consecutive secondary alignments (multi-mapping clusters in re-aligned or pangenome BAMs) silently dropped every read after the run — no warning, exit 0. Same trigger via a long run of hard-clipped MM/ML records. Default runs (`-F 0`) were unaffected, which is why this went unnoticed.

Found by a code review of #130; the code predates that PR (this fix applies to every fibertools release with `BamChunk`).

## The fix

`BamChunk::next` keeps pulling chunks until a record survives the filters or the underlying reader is truly exhausted (`pulled < chunk_size`). The invariant is documented at the iterator: it yields only non-empty chunks, and `None` strictly means exhausted — so `FiberseqRecords` needs no change.

## Test

New `tests/fiber_stream.rs` writes a synthetic BAM with 3,000 secondary records followed by 5 primaries and streams with `-F 0x100`: asserts all 5 primaries come out. Verified the test fails on the pre-fix code.

