### PR TITLE
chore: link changelog entries to pull requests

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -41,3 +41,18 @@ git_tag_name = "molecular-annotation-v{{ version }}"
 # semver_check is left off for now: it needs cargo-semver-checks installed in CI,
 # and conventional-commit bumping is sufficient. To enable later, add a
 # cargo-semver-checks install step to the workflow and set `semver_check = true`.
+
+[changelog]
+# Link each entry to its pull request, or to its commit when no PR is
+# known. release-plz fills commit.remote from the GitHub API in CI, so
+# rebase-merged commits resolve to their PR too. Same config as rustybam.
+body = """
+## [{{ version | trim_start_matches(pat="v") }}]{%- if release_link %}({{ release_link }}){% endif %} - {{ timestamp | date(format="%Y-%m-%d") }}
+{% for group, commits in commits | group_by(attribute="group") %}
+### {{ group | upper_first }}
+{% for commit in commits %}
+- {% if commit.breaking %}[**breaking**] {% endif %}{{ commit.message | split(pat="\n") | first | trim }}\
+{%- if commit.remote.pr_number %} ([#{{ commit.remote.pr_number }}]({{ remote.link }}/pull/{{ commit.remote.pr_number }})){% else %} ([{{ commit.id | truncate(length=7, end="") }}]({{ remote.link }}/commit/{{ commit.id }})){% endif %}
+{%- endfor %}
+{% endfor %}
+"""


### PR DESCRIPTION
Ports rustybam's `[changelog]` template to release-plz.toml. Each changelog entry links to its pull request — resolved via the GitHub API (`commit.remote.pr_number`), so it works for rebase-merged commits with no `(#N)` in the subject — falling back to a commit link when no PR is known. Once merged, release-plz regenerates the open v0.14.0 release PR with `(#130)` links on the rebase-merged entries.