### PR TITLE
ci: allow manual release-plz runs via workflow_dispatch

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -10,6 +10,7 @@ name: release-plz
 on:
   push:
     branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
Adds `workflow_dispatch` to the release-plz workflow so the open release PR can be refreshed on demand (`gh workflow run release-plz.yml`) without waiting for a push to main.