### PR TITLE
fix: true median for peak consensus boundaries

### DIFF
--- a/src/subcommands/call_peaks/peaks.rs
+++ b/src/subcommands/call_peaks/peaks.rs
@@ -37,7 +37,7 @@ pub fn reciprocal_overlap_raw(
 }
 
 /// Median of a sorted slice: middle value for odd counts, midpoint of the two middle
-/// values for even counts.
+/// values for even counts (added in a31e0d3, #129).
 fn median(sorted: &[i64]) -> i64 {
     let n = sorted.len();
     if n % 2 == 1 {


### PR DESCRIPTION
Changelog restoration: the actual fix shipped inside the #129 squash (consensus start/end were the upper median of pooled FIRE element edges, landing on one element's bounds whenever contributors tied; even counts now take the midpoint of the two middle values — 10 of 31 ctcf call-peaks boundaries shifted by 1–33 bp, summits and statistics unchanged). Squashing folded it into the union-peaks feat entry, so v0.14.0's changelog had no Fixed line for it. This PR carries the doc comment for the median function and, through its squash title, restores the changelog entry.